### PR TITLE
ESphere changes

### DIFF
--- a/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESAir.java
+++ b/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESAir.java
@@ -33,7 +33,7 @@ public class ESAir extends AvatarAbility implements AddonAbility {
 		if (currES.getAirUses() == 0) {
 			return;
 		}
-		if (!bPlayer.canBendIgnoreBindsCooldowns(this) || bPlayer.isOnCooldown("ESAir")) {
+		if (bPlayer.isOnCooldown("ESAir")) {
 			return;
 		}
 		setFields();

--- a/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESEarth.java
+++ b/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESEarth.java
@@ -43,7 +43,7 @@ public class ESEarth extends AvatarAbility implements AddonAbility {
 		if (currES.getEarthUses() == 0) {
 			return;
 		}
-		if (!bPlayer.canBendIgnoreBindsCooldowns(this) || bPlayer.isOnCooldown("ESEarth")) {
+		if (bPlayer.isOnCooldown("ESEarth")) {
 			return;
 		}
 		setFields();

--- a/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESFire.java
+++ b/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESFire.java
@@ -41,7 +41,7 @@ public class ESFire extends AvatarAbility implements AddonAbility {
 		if (currES.getFireUses() == 0) {
 			return;
 		}
-		if (!bPlayer.canBendIgnoreBindsCooldowns(this) || bPlayer.isOnCooldown("ESFire")) {
+		if (bPlayer.isOnCooldown("ESFire")) {
 			return;
 		}
 		setFields();

--- a/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESStream.java
+++ b/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESStream.java
@@ -53,7 +53,7 @@ public class ESStream extends AvatarAbility implements AddonAbility {
 			return;
 		}
 		ElementSphere currES = getAbility(player, ElementSphere.class);
-		if (!bPlayer.canBendIgnoreBindsCooldowns(this) || bPlayer.isOnCooldown("ESStream")) {
+		if (bPlayer.isOnCooldown("ESStream")) {
 			return;
 		}
 		setFields();

--- a/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESWater.java
+++ b/src/com/jedk1/jedcore/ability/avatar/elementsphere/ESWater.java
@@ -37,7 +37,7 @@ public class ESWater extends AvatarAbility implements AddonAbility {
 		if (currES.getWaterUses() == 0) {
 			return;
 		}
-		if (!bPlayer.canBendIgnoreBindsCooldowns(this) || bPlayer.isOnCooldown("ESWater")) {
+		if (bPlayer.isOnCooldown("ESWater")) {
 			return;
 		}
 		setFields();


### PR DESCRIPTION
for some reason having this prevents the attack move from working for non-ops, since the permissions nodes are checked in elementsphere.java this check isn't even necessary anyway