### PR TITLE
EarthLine clarified + more config options

### DIFF
--- a/src/com/jedk1/jedcore/ability/earthbending/EarthLine.java
+++ b/src/com/jedk1/jedcore/ability/earthbending/EarthLine.java
@@ -32,17 +32,18 @@ public class EarthLine extends EarthAbility implements AddonAbility {
 	private boolean progressing;
 	private boolean hitted;
 	private int goOnAfterHit;
+	private long removalTime = -1;
 
 	private long usecooldown;
 	private long preparecooldown;
+	private long maxduration;
 	private double range;
 	private double preparerange;
 	private double preparekeeprange;
 	private int affectingradius;
 	private double damage;
-	private CompositeRemovalPolicy removalPolicy;
-	
 	private boolean allowChangeDirection;
+	private CompositeRemovalPolicy removalPolicy;
 
 
 	public EarthLine(Player player) {
@@ -77,14 +78,15 @@ public class EarthLine extends EarthAbility implements AddonAbility {
 
 		this.removalPolicy.load(config);
 
-		usecooldown = config.getLong("Abilities.Earth.EarthLine.Cooldown", 3000);
-		preparecooldown = config.getLong("Abilities.Earth.EarthLine.PrepareCooldown", 0);
+		usecooldown = config.getLong("Abilities.Earth.EarthLine.Cooldown");
+		preparecooldown = config.getLong("Abilities.Earth.EarthLine.PrepareCooldown");
 		range = config.getInt("Abilities.Earth.EarthLine.Range");
-		preparerange = config.getDouble("Abilities.Earth.EarthLine.PrepareRange", 3);
-		preparekeeprange = config.getDouble("Abilities.Earth.EarthLine.PrepareKeepRange", 7);
+		preparerange = config.getDouble("Abilities.Earth.EarthLine.PrepareRange");
+		preparekeeprange = config.getDouble("Abilities.Earth.EarthLine.PrepareKeepRange");
 		affectingradius = config.getInt("Abilities.Earth.EarthLine.AffectingRadius");
 		damage = config.getDouble("Abilities.Earth.EarthLine.Damage");
-		allowChangeDirection = config.getBoolean("Abilities.Earth.EarthLine.AllowChangeDirection", true);
+		allowChangeDirection = config.getBoolean("Abilities.Earth.EarthLine.AllowChangeDirection");
+		maxduration = config.getLong("Abilities.Earth.EarthLine.MaxDuration");
 	}
 
 	public boolean prepare() {
@@ -153,6 +155,7 @@ public class EarthLine extends EarthAbility implements AddonAbility {
 
 	public void shootline(Location endLocation) {
 		if (usecooldown != 0 && bPlayer.getCooldown(this.getName()) < usecooldown) bPlayer.addCooldown(this, usecooldown);
+		if (maxduration > 0) removalTime = System.currentTimeMillis() + maxduration;
 		this.endLocation = endLocation;
 		progressing = true;
 		breakSourceBlock();
@@ -184,6 +187,11 @@ public class EarthLine extends EarthAbility implements AddonAbility {
 		}
 
 		if (removalPolicy.shouldRemove()) {
+			remove();
+			return;
+		}
+		
+		if (removalTime > -1 && System.currentTimeMillis() > removalTime) {
 			remove();
 			return;
 		}

--- a/src/com/jedk1/jedcore/ability/earthbending/EarthLine.java
+++ b/src/com/jedk1/jedcore/ability/earthbending/EarthLine.java
@@ -39,7 +39,7 @@ public class EarthLine extends EarthAbility implements AddonAbility {
 	private long maxduration;
 	private double range;
 	private double preparerange;
-	private double preparekeeprange;
+	private double sourcekeeprange;
 	private int affectingradius;
 	private double damage;
 	private boolean allowChangeDirection;
@@ -82,7 +82,7 @@ public class EarthLine extends EarthAbility implements AddonAbility {
 		preparecooldown = config.getLong("Abilities.Earth.EarthLine.PrepareCooldown");
 		range = config.getInt("Abilities.Earth.EarthLine.Range");
 		preparerange = config.getDouble("Abilities.Earth.EarthLine.PrepareRange");
-		preparekeeprange = config.getDouble("Abilities.Earth.EarthLine.PrepareKeepRange");
+		sourcekeeprange = config.getDouble("Abilities.Earth.EarthLine.SourceKeepRange");
 		affectingradius = config.getInt("Abilities.Earth.EarthLine.AffectingRadius");
 		damage = config.getDouble("Abilities.Earth.EarthLine.Damage");
 		allowChangeDirection = config.getBoolean("Abilities.Earth.EarthLine.AllowChangeDirection");
@@ -174,7 +174,7 @@ public class EarthLine extends EarthAbility implements AddonAbility {
 	}
 	
 	private boolean sourceOutOfRange() {
-		return sourceblock == null || sourceblock.getLocation().add(0.5, 0.5, 0.5).distanceSquared(player.getLocation()) > preparekeeprange * preparekeeprange || sourceblock.getWorld() != player.getWorld();
+		return sourceblock == null || sourceblock.getLocation().add(0.5, 0.5, 0.5).distanceSquared(player.getLocation()) > sourcekeeprange * sourcekeeprange || sourceblock.getWorld() != player.getWorld();
 	}
 
 	public void progress() {

--- a/src/com/jedk1/jedcore/configuration/JedCoreConfig.java
+++ b/src/com/jedk1/jedcore/configuration/JedCoreConfig.java
@@ -291,10 +291,14 @@ public class JedCoreConfig {
 			+ "If you then Left-Click at an object or player, a small piece of earth will come up "
 			+ "from the ground and move towards your target to deal damage and knock them back. "
 			+ "Additionally, hold Sneak to control the flow of the line!");
-		config.addDefault("Abilities.Earth.EarthLine.Cooldown", 3000);
+		config.addDefault("Abilities.Earth.EarthLine.Cooldown", 0);
+		config.addDefault("Abilities.Earth.EarthLine.PrepareCooldown", 3000);
 		config.addDefault("Abilities.Earth.EarthLine.Range", 30);
-		config.addDefault("Abilities.Earth.EarthLine.PrepareRange", 7);
+		config.addDefault("Abilities.Earth.EarthLine.PrepareRange", 3);
+		config.addDefault("Abilities.Earth.EarthLine.PrepareKeepRange", 7);
 		config.addDefault("Abilities.Earth.EarthLine.AffectingRadius", 2);
+		config.addDefault("Abilities.Earth.EarthLine.AllowChangeDirection", true);
+		config.addDefault("Abilities.Earth.EarthLine.MaxDuration", 2500);
 		config.addDefault("Abilities.Earth.EarthLine.Damage", 3.0);
 		config.addDefault("Abilities.Earth.EarthLine.RemovalPolicy.SwappedSlots.Enabled", false);
 		

--- a/src/com/jedk1/jedcore/configuration/JedCoreConfig.java
+++ b/src/com/jedk1/jedcore/configuration/JedCoreConfig.java
@@ -295,7 +295,7 @@ public class JedCoreConfig {
 		config.addDefault("Abilities.Earth.EarthLine.PrepareCooldown", 3000);
 		config.addDefault("Abilities.Earth.EarthLine.Range", 30);
 		config.addDefault("Abilities.Earth.EarthLine.PrepareRange", 3);
-		config.addDefault("Abilities.Earth.EarthLine.PrepareKeepRange", 7);
+		config.addDefault("Abilities.Earth.EarthLine.SourceKeepRange", 7);
 		config.addDefault("Abilities.Earth.EarthLine.AffectingRadius", 2);
 		config.addDefault("Abilities.Earth.EarthLine.AllowChangeDirection", true);
 		config.addDefault("Abilities.Earth.EarthLine.MaxDuration", 2500);


### PR DESCRIPTION
Explanation: You would think PrepareRange is actually the range you can select source blocks, but it is only the range that a source block will stay selected (the select range was always 3). I've changed this so that the PrepareRange is now the source select range, and SourceKeepRange is the maximum distance the player can walk away from the source block, before it's deselected/the earthline is removed.

I've also added two cooldowns, since it seems a bit odd for the cooldown to activate when the block is selected, rather than when the ability is used.

Changes:
- Changed PrepareRange to a double from the config; it also is now the range in which you can select blocks (that range was 3, and unchangeable before).
- Added SourceKeepRange, which acts like the old PrepareRange; also deselects the block if the player is outside of this range
- Added AllowChangeDirection
- Added PrepareCooldown
- Added MaxDuration (to prevent earthlines from being endlessly redirected by sneaking and twirling)