### PR TITLE
Change LavaThrow blast direction

### DIFF
--- a/src/com/jedk1/jedcore/ability/earthbending/LavaThrow.java
+++ b/src/com/jedk1/jedcore/ability/earthbending/LavaThrow.java
@@ -116,8 +116,7 @@ public class LavaThrow extends LavaAbility implements AddonAbility {
 		Block source = getRandomSourceBlock(location, 3);
 		if (source != null) {
 			shots++;
-			Vector direction = GeneralMethods.getDirection(player.getLocation(),
-					GeneralMethods.getTargetedLocation(player, range, Material.WATER, Material.LAVA)).normalize();
+			Vector direction = player.getEyeLocation().getDirection().clone().normalize();
 			Location origin = source.getLocation().clone().add(0, 2, 0);
 			Location head = origin.clone();
 			head.setDirection(direction);


### PR DESCRIPTION
Since the origin is starting 2 blocks above the source block, having the direction be from the player's feet to the target location gives a wonky upwards direction. Changed it to just be the direction the player is looking in.

Note: I did not test this change. Too much effort required.